### PR TITLE
Модуль блокировки стикерпаков

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,10 +14,11 @@ python_version = "3.6"
 
 python-telegram-bot = "*"
 peewee = "*"
-psycopg2 = "*"
+"psycopg2" = "*"
 feedparser = "*"
 python-dateutil = "*"
 python-dotenv = "*"
+supycache = "*"
 
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,20 +1,20 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a71fc52ac0341c87f7275f74835938db46717106160f8fb8c6505048c83b35dc"
+            "sha256": "aacfbd37fed2e4b859747bca5d640cb0127f39983636c3100db7d13df6256651"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
             "implementation_version": "3.6.3",
-            "os_name": "posix",
-            "platform_machine": "x86_64",
+            "os_name": "nt",
+            "platform_machine": "AMD64",
             "platform_python_implementation": "CPython",
-            "platform_release": "4.13.0-21-generic",
-            "platform_system": "Linux",
-            "platform_version": "#24~16.04.1-Ubuntu SMP Mon Dec 18 19:39:31 UTC 2017",
+            "platform_release": "10",
+            "platform_system": "Windows",
+            "platform_version": "10.0.14393",
             "python_full_version": "3.6.3",
             "python_version": "3.6",
-            "sys_platform": "linux"
+            "sys_platform": "win32"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -126,6 +126,13 @@
                 "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
             ],
             "version": "==1.11.0"
+        },
+        "supycache": {
+            "hashes": [
+                "sha256:b85547195e1effffc14b7d06f58664a5cc657edb4794046d1d5eb42983247760",
+                "sha256:37aeac3074dda828b84c9614896f8b9c775700068cac1551af86945bba4cedb6"
+            ],
+            "version": "==0.3.0"
         }
     },
     "develop": {}

--- a/bot.py
+++ b/bot.py
@@ -7,6 +7,7 @@ from telegram.ext import (CommandHandler, Dispatcher, Filters, MessageHandler,
 
 from model import init_database
 from modules.admin import Admin
+from modules.block_stickerpack import BlockStickerpack
 from modules.forward import Forward
 from modules.kto_zloy import KtoZloy
 from modules.primitive_response import PrimitiveResponse
@@ -79,6 +80,9 @@ class Bot:
 
         primitive_response = PrimitiveResponse(CHAT_ID)
         primitive_response.add_handlers(self._updater.dispatcher.add_handler)
+
+        block_stickerpack = BlockStickerpack(CHAT_ID, ADMIN_ID)
+        block_stickerpack.add_handlers(self._updater.dispatcher.add_handler)
         
         self._updater.dispatcher.add_error_handler(self._error)
     

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -19,9 +19,10 @@ from model.user import User
 from model.user_messages_info import UserMessagesInfo
 from model.feed import Feed
 from model.last_users import LastUsers
+from model.blocked_stickerpack import BlockedStickerpack
 
 
 def init_database():
     database.connect()
     database.create_tables(
-        [User, UserMessagesInfo, Feed, LastUsers], True)
+        [User, UserMessagesInfo, Feed, LastUsers, BlockedStickerpack], True)

--- a/model/blocked_stickerpack.py
+++ b/model/blocked_stickerpack.py
@@ -1,0 +1,10 @@
+from peewee import *
+
+from model.base_entity import BaseEntity
+
+
+class BlockedStickerpack(BaseEntity):
+    name = TextField()
+    
+    class Meta:
+        db_table = 'blocked_stickerpacks'

--- a/modules/block_stickerpack.py
+++ b/modules/block_stickerpack.py
@@ -16,11 +16,11 @@ class BlockStickerpack:
         self._admin_id = admin_id
 
     def add_handlers(self, add_handler):
+        add_handler(MessageHandler(Filters.sticker, self._watchdog))
         add_handler(CommandHandler('block_stickerpack', callback=self._block))
         add_handler(CommandHandler('unblock_stickerpack', callback=self._unblock))
         add_handler(CallbackQueryHandler(self._unblock_stickerpack_button))
         add_handler(CommandHandler('list_stickerpacks', callback=self._list))
-        add_handler(MessageHandler(Filters.sticker, self._watchdog))
 
     def _get_stickers_link(self, stickerpack_name):
         return self._STICKER_ADD_URL + stickerpack_name
@@ -108,7 +108,7 @@ class BlockStickerpack:
         if message.chat_id not in (self._chat_id, self._admin_id):
             return
 
-        if message.from_user.id not in get_admin_ids(bot, message.chat_id):
+        if query.from_user.id not in get_admin_ids(bot, message.chat_id):
             bot.answer_callback_query(query.id, self._ADMIN_RESTRICTION_MESSAGE, show_alert=True)
             return
 

--- a/modules/block_stickerpack.py
+++ b/modules/block_stickerpack.py
@@ -1,0 +1,136 @@
+from peewee import DoesNotExist
+from telegram import ParseMode, InlineKeyboardButton, ReplyKeyboardMarkup, InlineKeyboardMarkup, ChatMember
+from telegram.ext import CommandHandler, Filters, MessageHandler, CallbackQueryHandler
+
+from model import BlockedStickerpack
+from utils import get_admin_ids
+
+
+class BlockStickerpack:
+    _STICKER_ADD_URL = 'https://t.me/addstickers/'
+    _ADMIN_RESTRICTION_MESSAGE = 'Эта функция предназначена только для администраторов бота!'
+    _NO_STICKERPACKS_BLOCKED_MESSAGE = 'Заблокированных стикерпаков пока нет.'
+
+    def __init__(self, chat_id, admin_id):
+        self._chat_id = chat_id
+        self._admin_id = admin_id
+
+    def add_handlers(self, add_handler):
+        add_handler(CommandHandler('block_stickerpack', callback=self._block))
+        add_handler(CommandHandler('unblock_stickerpack', callback=self._unblock))
+        add_handler(CallbackQueryHandler(self._unblock_stickerpack_button))
+        add_handler(CommandHandler('list_stickerpacks', callback=self._list))
+        add_handler(MessageHandler(Filters.sticker, self._watchdog))
+
+    def _get_stickers_link(self, stickerpack_name):
+        return self._STICKER_ADD_URL + stickerpack_name
+
+    def _get_blocked_stickerpacks(self):
+        return BlockedStickerpack.select()
+
+    def _list(self, bot, update):
+        message = update.message
+
+        queryset = self._get_blocked_stickerpacks()
+
+        if queryset:
+            stickerpacks_list = (f'{index}. [{stickerpack.name}]({self._get_stickers_link(stickerpack.name)})'
+                                 for index, stickerpack in enumerate(queryset, start=1))
+            response_text = 'Заблокированные стикерпаки:\n' + '\n'.join(stickerpacks_list)
+        else:
+            response_text = self._NO_STICKERPACKS_BLOCKED_MESSAGE
+
+        message.reply_text(text=response_text, parse_mode=ParseMode.MARKDOWN, quote=False)
+        message.delete()
+
+    def _block(self, bot, update):
+        message = update.message
+
+        if message.chat_id not in (self._chat_id, self._admin_id):
+            return
+
+        admin_ids = get_admin_ids(bot, message.chat_id)
+        user_id = message.from_user.id
+
+        if user_id not in admin_ids:
+            message.reply_text(text=self._ADMIN_RESTRICTION_MESSAGE, quote=False)
+            message.delete()
+            return
+
+        if message.reply_to_message is None or message.reply_to_message.sticker is None:
+            message.reply_text(text='Команда предназначена только для ответа на сообщения со стикером!', quote=False)
+            message.delete()
+            return
+
+        sticker = message.reply_to_message.sticker
+
+        stickerpack, created = BlockedStickerpack.get_or_create(name=sticker.set_name)
+
+        if not created:
+            response_text = f'Стикерпак [{stickerpack.name}]({self._get_stickers_link(stickerpack.name)}) уже заблокирован.'
+        else:
+            response_text = f'Стикерпак [{stickerpack.name}]({self._get_stickers_link(stickerpack.name)}) успешно заблокирован!\n' \
+                            f'Стикер отправил: {message.reply_to_message.from_user.name} | Заблокировал: {message.from_user.name}'
+
+        message.reply_text(text=response_text, parse_mode=ParseMode.MARKDOWN, quote=False)
+        message.reply_to_message.delete()
+        message.delete()
+
+    def _unblock(self, bot, update):
+        message = update.message
+
+        if message.chat_id not in (self._chat_id, self._admin_id):
+            return
+
+        if message.from_user.id not in get_admin_ids(bot, message.chat_id):
+            message.reply_text(text=self._ADMIN_RESTRICTION_MESSAGE, quote=False)
+            message.delete()
+            return
+
+        blocked_stickerpacks = self._get_blocked_stickerpacks()
+        if not blocked_stickerpacks:
+            response_text = self._NO_STICKERPACKS_BLOCKED_MESSAGE
+            reply_markup = None
+        else:
+            response_text = 'Выберите стикерпак, который нужно разблокировать:'
+            keyboard = [[InlineKeyboardButton(f'{index}. {sp.name}', callback_data=sp.name)] for index, sp in
+                        enumerate(blocked_stickerpacks, start=1)]
+            reply_markup = InlineKeyboardMarkup(keyboard, one_time_keyboard=True)
+
+        message.reply_text(text=response_text, parse_mode=ParseMode.MARKDOWN, reply_markup=reply_markup, quote=False)
+        message.delete()
+
+    def _unblock_stickerpack_button(self, bot, update):
+        query = update.callback_query
+
+        message = query.message
+
+        if message.chat_id not in (self._chat_id, self._admin_id):
+            return
+
+        if message.from_user.id not in get_admin_ids(bot, message.chat_id):
+            bot.answer_callback_query(query.id, self._ADMIN_RESTRICTION_MESSAGE, show_alert=True)
+            return
+
+        stickerpack_name = query.data
+
+        try:
+            stickerpack = BlockedStickerpack.get(BlockedStickerpack.name == stickerpack_name)
+        except DoesNotExist:
+            response_text = f'Стикерпак "{stickerpack_name}" не был найден в списке заблокированных.'
+        else:
+            stickerpack.delete_instance()
+            response_text = f'Стикерпак [{query.data}]({self._get_stickers_link(stickerpack.name)}) успешно разблокирован.'
+
+        message.edit_text(text=response_text, parse_mode=ParseMode.MARKDOWN)
+
+    def _watchdog(self, bot, update):
+        message = update.message
+        sticker = message.sticker
+
+        try:
+            queryset = BlockedStickerpack.get(BlockedStickerpack.name == sticker.set_name)
+        except DoesNotExist:
+            return
+
+        message.delete()

--- a/modules/block_stickerpack.py
+++ b/modules/block_stickerpack.py
@@ -1,5 +1,5 @@
 from peewee import DoesNotExist
-from telegram import ParseMode, InlineKeyboardButton, ReplyKeyboardMarkup, InlineKeyboardMarkup, ChatMember
+from telegram import ParseMode, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import CommandHandler, Filters, MessageHandler, CallbackQueryHandler
 
 from model import BlockedStickerpack
@@ -25,7 +25,8 @@ class BlockStickerpack:
     def _get_stickers_link(self, stickerpack_name):
         return self._STICKER_ADD_URL + stickerpack_name
 
-    def _get_blocked_stickerpacks(self):
+    @staticmethod
+    def _get_blocked_stickerpacks():
         return BlockedStickerpack.select()
 
     def _list(self, bot, update):
@@ -124,12 +125,13 @@ class BlockStickerpack:
 
         message.edit_text(text=response_text, parse_mode=ParseMode.MARKDOWN)
 
-    def _watchdog(self, bot, update):
+    @staticmethod
+    def _watchdog(bot, update):
         message = update.message
         sticker = message.sticker
 
         try:
-            queryset = BlockedStickerpack.get(BlockedStickerpack.name == sticker.set_name)
+            BlockedStickerpack.get(BlockedStickerpack.name == sticker.set_name)
         except DoesNotExist:
             return
 

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,8 @@
+from itertools import zip_longest
+
+import supycache
+
+
+@supycache.supycache(cache_key='admin_ids_{1}', max_age=10 * 60)
+def get_admin_ids(bot, chat_id):
+    return [admin.user.id for admin in bot.get_chat_administrators(chat_id)]

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,3 @@
-from itertools import zip_longest
-
 import supycache
 
 


### PR DESCRIPTION
Модуль позволяет:
 - блокировать стикерпак, если ответить командой `/block_stickerpack` на стикер (только администратор группы)
 - разблокировать стикерпак (только администратор группы)
 - показать список заблокированных стикерпаков (все пользователи)
 - автоматически удалять сообщения со стикерами из заблокированных стикерпаков

Возможный вариант настроек команд для _BotFather_:
```
block_stickerpack - ответьте командой на стикер, чтобы заблокировать стикерпак
unblock_stickerpack - выберите из списка нужный стикерпак, чтобы разблокировать его
list_stickerpacks - список заблокированных стикерпаков
```

Список заблокированных стикерпаков хранится в базе.

Дополнительно добавлена функция (в `utils.py`) для получения администраторов группы.
Для уменьшения количества запросов - данная функция кешируется на 10 минут.

Для кеширования использовался пакет [supycache](https://github.com/lonetwin/supycache).

