### PR TITLE
Изменение прав модуля "block_stickerpack", унификация функционала

### DIFF
--- a/filters.py
+++ b/filters.py
@@ -20,4 +20,3 @@ class PermittedChatFilter(BaseFilter):
 
     def filter(self, message):
         return message.chat_id in self._chat_ids
-

--- a/filters.py
+++ b/filters.py
@@ -1,7 +1,5 @@
 from telegram.ext import BaseFilter
 
-from settings import CHAT_ID, ADMIN_ID
-
 
 class ReplyToBotFilter(BaseFilter):
     def filter(self, message):

--- a/filters.py
+++ b/filters.py
@@ -1,0 +1,22 @@
+from telegram.ext import BaseFilter
+
+from settings import CHAT_ID, ADMIN_ID
+
+
+class ReplyToBotFilter(BaseFilter):
+    def filter(self, message):
+        bot_username = message.bot.username
+        reply = message.reply_to_message
+
+        return bool(reply) and reply.from_user.name == bot_username
+
+
+reply_to_bot_filter = ReplyToBotFilter()
+
+
+class PermittedChatFilter(BaseFilter):
+    def filter(self, message):
+        return message.chat_id in (ADMIN_ID, CHAT_ID)
+
+
+permitted_chat_filter = PermittedChatFilter()

--- a/filters.py
+++ b/filters.py
@@ -15,8 +15,9 @@ reply_to_bot_filter = ReplyToBotFilter()
 
 
 class PermittedChatFilter(BaseFilter):
+    def __init__(self, chat_ids):
+        self._chat_ids = chat_ids
+
     def filter(self, message):
-        return message.chat_id in (ADMIN_ID, CHAT_ID)
+        return message.chat_id in self._chat_ids
 
-
-permitted_chat_filter = PermittedChatFilter()

--- a/modules/block_stickerpack.py
+++ b/modules/block_stickerpack.py
@@ -49,7 +49,6 @@ class BlockStickerpack:
             response_text = self._NO_STICKERPACKS_BLOCKED_MESSAGE
 
         message.reply_text(text=response_text, parse_mode=ParseMode.MARKDOWN, quote=False)
-        message.delete()
 
     def _block(self, bot, update):
         message = update.message
@@ -60,7 +59,6 @@ class BlockStickerpack:
 
         if message.reply_to_message is None or message.reply_to_message.sticker is None:
             message.reply_text(text='Команда предназначена только для ответа на сообщения со стикером!', quote=False)
-            message.delete()
             return
 
         sticker = message.reply_to_message.sticker
@@ -74,8 +72,6 @@ class BlockStickerpack:
                             f'Стикер отправил: {message.reply_to_message.from_user.name} | Заблокировал: {message.from_user.name}'
 
         message.reply_text(text=response_text, parse_mode=ParseMode.MARKDOWN, quote=False)
-        message.reply_to_message.delete()
-        message.delete()
 
     def _unblock(self, bot, update):
         message = update.message
@@ -95,7 +91,6 @@ class BlockStickerpack:
             reply_markup = InlineKeyboardMarkup(keyboard, one_time_keyboard=True)
 
         message.reply_text(text=response_text, parse_mode=ParseMode.MARKDOWN, reply_markup=reply_markup, quote=False)
-        message.delete()
 
     def _unblock_stickerpack_button(self, bot, update):
         query = update.callback_query

--- a/modules/block_stickerpack.py
+++ b/modules/block_stickerpack.py
@@ -19,7 +19,7 @@ class BlockStickerpack:
         self.permitted_chat_filter = PermittedChatFilter([self._admin_id, self._chat_id])
 
     def add_handlers(self, add_handler):
-        add_handler(MessageHandler(PermittedChatFilter([self._admin_id, self._chat_id]) & ~Filters.private & Filters.sticker, self._watchdog))
+        add_handler(MessageHandler(self.permitted_chat_filter & ~Filters.private & Filters.sticker, self._watchdog))
         add_handler(CommandHandler('block_stickerpack',
                                    callback=self._block,
                                    filters=self.permitted_chat_filter))
@@ -55,7 +55,8 @@ class BlockStickerpack:
     def _block(self, bot, update):
         message = update.message
 
-        if message.from_user.id != self._admin_id and not is_user_group_admin(bot, message.from_user.id, message.chat_id):
+        if message.from_user.id != self._admin_id and not is_user_group_admin(bot, message.from_user.id,
+                                                                              message.chat_id, self._admin_id):
             message.reply_text(text=self._ADMIN_RESTRICTION_MESSAGE, quote=False)
             return
 
@@ -78,7 +79,8 @@ class BlockStickerpack:
     def _unblock(self, bot, update):
         message = update.message
 
-        if message.from_user.id != self._admin_id and not is_user_group_admin(bot, message.from_user.id, message.chat_id):
+        if message.from_user.id != self._admin_id and not is_user_group_admin(bot, message.from_user.id,
+                                                                              message.chat_id, self._admin_id):
             message.reply_text(text=self._ADMIN_RESTRICTION_MESSAGE, quote=False)
             return
 
@@ -97,7 +99,8 @@ class BlockStickerpack:
     def _unblock_stickerpack_button(self, bot, update):
         query = update.callback_query
 
-        if query.from_user.id != self._admin_id and not is_user_group_admin(bot, query.from_user.id, query.message.chat_id):
+        if query.from_user.id != self._admin_id and not is_user_group_admin(bot, query.from_user.id,
+                                                                            query.message.chat_id, self._admin_id):
             bot.answer_callback_query(query.id, self._ADMIN_RESTRICTION_MESSAGE, show_alert=True)
             return
 

--- a/modules/block_stickerpack.py
+++ b/modules/block_stickerpack.py
@@ -3,6 +3,7 @@ from telegram import ParseMode, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import CommandHandler, Filters, MessageHandler, CallbackQueryHandler
 
 from model import BlockedStickerpack
+from settings import ADMIN_ID
 from utils import is_user_group_admin
 from filters import permitted_chat_filter
 
@@ -20,13 +21,13 @@ class BlockStickerpack:
         add_handler(MessageHandler(permitted_chat_filter & ~Filters.private & Filters.sticker, self._watchdog))
         add_handler(CommandHandler('block_stickerpack',
                                    callback=self._block,
-                                   filters=permitted_chat_filter & ~Filters.private))
+                                   filters=permitted_chat_filter))
         add_handler(CommandHandler('unblock_stickerpack',
                                    callback=self._unblock,
-                                   filters=permitted_chat_filter & ~Filters.private))
+                                   filters=permitted_chat_filter))
         add_handler(CommandHandler('list_stickerpacks',
                                    callback=self._list,
-                                   filters=permitted_chat_filter & ~Filters.private))
+                                   filters=permitted_chat_filter))
         add_handler(CallbackQueryHandler(self._unblock_stickerpack_button))
 
     def _get_stickers_link(self, stickerpack_name):
@@ -53,7 +54,7 @@ class BlockStickerpack:
     def _block(self, bot, update):
         message = update.message
 
-        if not is_user_group_admin(bot, message.from_user.id, message.chat_id):
+        if message.from_user.id != ADMIN_ID and not is_user_group_admin(bot, message.from_user.id, message.chat_id):
             message.reply_text(text=self._ADMIN_RESTRICTION_MESSAGE, quote=False)
             return
 
@@ -76,7 +77,7 @@ class BlockStickerpack:
     def _unblock(self, bot, update):
         message = update.message
 
-        if not is_user_group_admin(bot, message.from_user.id, message.chat_id):
+        if message.from_user.id != ADMIN_ID and not is_user_group_admin(bot, message.from_user.id, message.chat_id):
             message.reply_text(text=self._ADMIN_RESTRICTION_MESSAGE, quote=False)
             return
 
@@ -95,7 +96,7 @@ class BlockStickerpack:
     def _unblock_stickerpack_button(self, bot, update):
         query = update.callback_query
 
-        if not is_user_group_admin(bot, query.from_user.id, query.message.chat_id):
+        if query.from_user.id != ADMIN_ID and not is_user_group_admin(bot, query.from_user.id, query.message.chat_id):
             bot.answer_callback_query(query.id, self._ADMIN_RESTRICTION_MESSAGE, show_alert=True)
             return
 

--- a/modules/primitive_response.py
+++ b/modules/primitive_response.py
@@ -1,24 +1,15 @@
 import re
 from random import choice, randint
 
-from telegram.ext import BaseFilter, CommandHandler, Filters, MessageHandler
+from telegram.ext import CommandHandler, Filters, MessageHandler
 
-
-class ReplyToBotFilter(BaseFilter):
-    def filter(self, message):
-        bot_username = message.bot.username
-        reply = message.reply_to_message
-        
-        return bool(reply) and reply.from_user.name == bot_username
-
-
-reply_to_bot_filter = ReplyToBotFilter()
+from filters import reply_to_bot_filter
 
 
 class PrimitiveResponse:
     def __init__(self, chat_id):
         self._chat_id = chat_id
-    
+
     def add_handlers(self, add_handler):
         add_handler(MessageHandler(Filters.text, self.text_responses))
         add_handler(
@@ -36,35 +27,35 @@ class PrimitiveResponse:
                     bot.sendMessage(chat_id=chat_id, text=answer,
                                     reply_to_message_id=message_id,
                                     markdown_support=True)
-        
+
         message = update.message
         chat_id = message.chat_id
         text = message.text.lower()
         message_id = message.message_id
-        
+
         text_response(['ты злой', 'злой ты', 'ты - злой', 'вы злые', 'злые вы',
                        'вы - злые', 'вы все злые'], 'ты злой!')
-        
+
         text_response(['спать', 'посплю'], 'snov.txt')
-        
+
         text_response(['бот злой'], 'Ты не лучше.')
 
         text_response([r'иди на ?хуй', r'на ?хуй пошел', r'на ?хуй иди',
                        r'пошел на ?хуй'], 'nahui.txt')
-        
+
         text_response(['бот пидор', 'бот идиот', 'бот мудак'], 'И?')
-        
+
         text_response(['бот умер'], 'Герої не вмирають! 🇺🇦')
-        
+
         text_response(['бот няша'], 'Спасибо, ты тоже <3')
-        
+
         text_response(['бот жив', 'бот, ты жив', 'ты жив, бот'],
                       'Так точно, капитан')
-        
+
         text_response(['утра', 'доброе утро', 'утречка'], 'utro.txt')
-        
+
         text_response(['украин'], '🇺🇦')
-        
+
         text_response(['рот ебал', 'ебал в рот'], 'Фуууу, противно!')
 
         text_response([r'\bага$'], 'в жопе нога', 33)
@@ -76,22 +67,22 @@ class PrimitiveResponse:
             if any(re.search(pattern, text) for pattern in patterns):
                 if answer.endswith('.txt'):
                     answer = self._choice_variant_from_file(answer)
-            
+
                 if randint(1, 100) <= chance:
                     bot.sendMessage(chat_id=chat_id, text=answer,
                                     reply_to_message_id=message_id,
                                     markdown_support=True)
-    
+
         message = update.message
         chat_id = message.chat_id
         text = message.text.lower()
         message_id = message.message_id
-    
+
         reply_response(['.*'], "Чё сказал?", 33)
-    
+
     def _me(self, bot, update, args):
         message = update.message
-        
+
         text = "{0} {1}".format(message.from_user.name, ' '.join(args))
         bot.sendMessage(chat_id=self._chat_id, text=text)
 

--- a/utils.py
+++ b/utils.py
@@ -1,14 +1,12 @@
 import supycache
 
-from settings import ADMIN_ID
-
 
 @supycache.supycache(cache_key='admin_ids_{1}', max_age=10 * 60)
 def get_admin_ids(bot, chat_id):
     return [admin.user.id for admin in bot.get_chat_administrators(chat_id)]
 
 
-def is_user_group_admin(bot, user_id, chat_id_):
-    if chat_id_ == ADMIN_ID:
+def is_user_group_admin(bot, user_id, chat_id_, admin_id):
+    if chat_id_ == admin_id:
         return False
     return user_id in get_admin_ids(bot, chat_id_)

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,14 @@
 import supycache
 
+from settings import ADMIN_ID
+
 
 @supycache.supycache(cache_key='admin_ids_{1}', max_age=10 * 60)
 def get_admin_ids(bot, chat_id):
     return [admin.user.id for admin in bot.get_chat_administrators(chat_id)]
+
+
+def is_user_group_admin(bot, user_id, chat_id_):
+    if chat_id_ == ADMIN_ID:
+        return False
+    return user_id in get_admin_ids(bot, chat_id_)


### PR DESCRIPTION
 - теперь модуль позволяет администратору смотреть, блокировать, разблокировать стикерпаки из личной переписки с ботом 
 - часть прав вынесена в кастомный фильтр ([Advanced-Filters#custom-filters](https://github.com/python-telegram-bot/python-telegram-bot/wiki/Extensions-%E2%80%93-Advanced-Filters#custom-filters))
 - фильтры вынесены в отдельный файл
 - функционал пытается быть универсальным и не зависеть от глобальных настроек :-)