### PR TITLE
Модуль, который отображает закрепленное сообщение & фильтр супергруппы

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -12,6 +12,7 @@ from modules.forward import Forward
 from modules.kto_zloy import KtoZloy
 from modules.primitive_response import PrimitiveResponse
 from modules.random_reaction import random_reaction
+from modules.reply_to_pin import ReplyToPin
 from modules.resolve import resolve
 from modules.statistic import Statistic
 from settings import ADMIN_ID, CHAT_ID, ENV, PORT, TOKEN, URL
@@ -83,6 +84,9 @@ class Bot:
 
         block_stickerpack = BlockStickerpack(CHAT_ID, ADMIN_ID)
         block_stickerpack.add_handlers(self._updater.dispatcher.add_handler)
+
+        reply_to_pin = ReplyToPin(CHAT_ID, ADMIN_ID)
+        reply_to_pin.add_handlers(self._updater.dispatcher.add_handler)
         
         self._updater.dispatcher.add_error_handler(self._error)
     

--- a/filters.py
+++ b/filters.py
@@ -1,3 +1,4 @@
+from telegram import Chat
 from telegram.ext import BaseFilter
 
 
@@ -10,6 +11,14 @@ class ReplyToBotFilter(BaseFilter):
 
 
 reply_to_bot_filter = ReplyToBotFilter()
+
+
+class SuperGroupFilter(BaseFilter):
+    def filter(self, message):
+        return message.chat.type == Chat.SUPERGROUP
+
+
+supergroup_filter = SuperGroupFilter()
 
 
 class PermittedChatFilter(BaseFilter):

--- a/modules/reply_to_pin.py
+++ b/modules/reply_to_pin.py
@@ -1,0 +1,36 @@
+from telegram.ext import CommandHandler
+
+from filters import PermittedChatFilter, supergroup_filter
+
+
+class ReplyToPin:
+    MESSAGES_TO_RESPOND = 50
+
+    def __init__(self, chat_id, admin_id):
+        self._chat_id = chat_id
+        self._admin_id = admin_id
+
+        self.permitted_chat_filter = PermittedChatFilter([self._chat_id])
+
+        self.last_message_id = None
+
+    def add_handlers(self, add_handler):
+        add_handler(CommandHandler('pinned', callback=self.reply_to_pin,
+                                   filters=self.permitted_chat_filter & supergroup_filter))
+
+    def reply_to_pin(self, bot, update):
+        message = update.message
+
+        if self.last_message_id is None:
+            self.last_message_id = message.message_id - self.MESSAGES_TO_RESPOND
+
+        if message.message_id - self.last_message_id < self.MESSAGES_TO_RESPOND:
+            return
+
+        chat = bot.get_chat(message.chat_id)
+        if chat.pinned_message is None:
+            return
+
+        chat.pinned_message.reply_text('☝️️', disable_notification=True)
+
+        self.last_message_id = message.message_id


### PR DESCRIPTION
Модуль позволяет по команде `/pinned` отобразить закрепленное сообщение в супергруппе.

Почему в только супергруппе? [Потому что ](http://python-telegram-bot.readthedocs.io/en/stable/telegram.chat.html?highlight=pinned_message#Chat.pinned_message)закрепленные сообщения доступны только там.

Для проверки чата, является ли он супергруппой - создан соответственный фильтр.

Во избежание злоупотребления командой  - срабатывать она будет раз в `MESSAGES_TO_RESPOND` (_default:_ `50`) сообщений в чате. 