### PR TITLE
Добавлен модуль "капчи" новых пользователей чата + связные правки

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -15,6 +15,7 @@ from modules.random_reaction import random_reaction
 from modules.reply_to_pin import ReplyToPin
 from modules.resolve import resolve
 from modules.statistic import Statistic
+from modules.user_join_captcha import UserJoinCaptcha
 from settings import ADMIN_ID, CHAT_ID, ENV, PORT, TOKEN, URL
 
 
@@ -87,6 +88,9 @@ class Bot:
 
         reply_to_pin = ReplyToPin(CHAT_ID, ADMIN_ID)
         reply_to_pin.add_handlers(self._updater.dispatcher.add_handler)
+
+        user_join_captcha = UserJoinCaptcha(CHAT_ID, ADMIN_ID)
+        user_join_captcha.add_handlers(self._updater.dispatcher.add_handler)
         
         self._updater.dispatcher.add_error_handler(self._error)
     

--- a/bot.py
+++ b/bot.py
@@ -17,6 +17,7 @@ from modules.resolve import resolve
 from modules.statistic import Statistic
 from modules.user_join_captcha import UserJoinCaptcha
 from settings import ADMIN_ID, CHAT_ID, ENV, PORT, TOKEN, URL
+from settings import USER_JOIN_CAPTCHA_ENABLED
 
 
 def process_update(obj, update):
@@ -89,8 +90,9 @@ class Bot:
         reply_to_pin = ReplyToPin(CHAT_ID, ADMIN_ID)
         reply_to_pin.add_handlers(self._updater.dispatcher.add_handler)
 
-        user_join_captcha = UserJoinCaptcha(CHAT_ID, ADMIN_ID)
-        user_join_captcha.add_handlers(self._updater.dispatcher.add_handler)
+        if USER_JOIN_CAPTCHA_ENABLED:
+            user_join_captcha = UserJoinCaptcha(CHAT_ID, ADMIN_ID)
+            user_join_captcha.add_handlers(self._updater.dispatcher.add_handler)
         
         self._updater.dispatcher.add_error_handler(self._error)
     

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -26,4 +26,4 @@ from model.blocked_stickerpack import BlockedStickerpack
 def init_database():
     database.connect()
     database.create_tables(
-        [User, UserMessagesInfo, Feed, LastUsers, BlockedStickerpack], True)
+        [User, UserMessagesInfo, Feed, LastUsers, BlockedStickerpack])

--- a/modules/block_stickerpack.py
+++ b/modules/block_stickerpack.py
@@ -5,6 +5,7 @@ from telegram.ext import CommandHandler, Filters, MessageHandler, CallbackQueryH
 from filters import PermittedChatFilter
 from model import BlockedStickerpack
 from utils import is_user_group_admin, get_username_or_name
+from utils import set_callback_data, process_callback_query, get_callback_data
 
 
 class BlockStickerpack:
@@ -92,19 +93,17 @@ class BlockStickerpack:
             reply_markup = None
         else:
             response_text = 'Выберите стикерпак, который нужно разблокировать:'
-            keyboard = [[InlineKeyboardButton(f'{index}. {sp.name}', callback_data=f'{__name__}/{sp.name}')]
+            keyboard = [[InlineKeyboardButton(f'{index}. {sp.name}', callback_data=set_callback_data(sp.name))]
                         for index, sp in enumerate(blocked_stickerpacks, start=1)]
             reply_markup = InlineKeyboardMarkup(keyboard, one_time_keyboard=True)
 
         message.reply_text(text=response_text, parse_mode=ParseMode.MARKDOWN, reply_markup=reply_markup, quote=False)
 
+    @process_callback_query
     def _unblock_stickerpack_button(self, bot, update):
         query = update.callback_query
 
-        module, pack_name = query.data.split('/')
-
-        if module != __name__:
-            return
+        pack_name = get_callback_data(query.data)
 
         if query.from_user.id != self._admin_id and not is_user_group_admin(bot, query.from_user.id,
                                                                             query.message.chat_id, self._admin_id):

--- a/modules/block_stickerpack.py
+++ b/modules/block_stickerpack.py
@@ -92,7 +92,7 @@ class BlockStickerpack:
             reply_markup = None
         else:
             response_text = 'Выберите стикерпак, который нужно разблокировать:'
-            keyboard = [[InlineKeyboardButton(f'{index}. {sp.name}', callback_data=sp.name)]
+            keyboard = [[InlineKeyboardButton(f'{index}. {sp.name}', callback_data=f'{__name__}/{sp.name}')]
                         for index, sp in enumerate(blocked_stickerpacks, start=1)]
             reply_markup = InlineKeyboardMarkup(keyboard, one_time_keyboard=True)
 
@@ -101,6 +101,11 @@ class BlockStickerpack:
     def _unblock_stickerpack_button(self, bot, update):
         query = update.callback_query
 
+        module, pack_name = query.data.split('/')
+
+        if module != __name__:
+            return
+
         if query.from_user.id != self._admin_id and not is_user_group_admin(bot, query.from_user.id,
                                                                             query.message.chat_id, self._admin_id):
             bot.answer_callback_query(query.id, self._ADMIN_RESTRICTION_MESSAGE, show_alert=True)
@@ -108,7 +113,6 @@ class BlockStickerpack:
 
         message = query.message
 
-        pack_name = query.data
         pack_link = self._get_stickers_link(pack_name)
 
         try:

--- a/modules/user_join_captcha.py
+++ b/modules/user_join_captcha.py
@@ -1,0 +1,76 @@
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+from telegram.ext import MessageHandler, CallbackQueryHandler
+from telegram.ext.filters import Filters
+
+from filters import PermittedChatFilter, supergroup_filter
+from utils import get_username_or_name
+
+
+class UserJoinCaptcha:
+    _ON_JOIN_MESSAGE = 'Привет, {username}!\n' \
+                       'Сейчас ты ничего не можешь писать в чат.\n' \
+                       'Чтобы снять это ограничение - нажми на кнопку под этим сообщением! 👇'
+    _ON_APPROVE_MESSAGE = '{username}, ты доказал, что ты не бот. 🤓\n' \
+                          'Либо очень умный бот. 🤖 Нам такие тоже подходят.\n\n' \
+                          'Добро пожаловать. 👊'
+    _ON_ACCESS_RESTRICTED_MESSAGE = 'ЭТО НЕ ТВОЯ БИТВА, {username}! ⚔️'
+    _INLINE_BUTTON_TEXT = 'Я не бот! ✊️'
+
+    def __init__(self, chat_id, admin_id):
+        self._chat_id = chat_id
+        self._admin_id = admin_id
+
+        self.permitted_chat_filter = PermittedChatFilter([self._chat_id])
+
+    def add_handlers(self, add_handler):
+        add_handler(MessageHandler(
+            filters=self.permitted_chat_filter & supergroup_filter & Filters.status_update.new_chat_members,
+            callback=self._send_captcha))
+
+        add_handler(CallbackQueryHandler(self._process_captcha))
+
+    def _send_captcha(self, bot, update):
+        message = update.message
+        user = update.message.from_user
+
+        if user.id == self._admin_id:
+            return
+
+        username = get_username_or_name(user)
+
+        bot.restrict_chat_member(self._chat_id,
+                                 user.id,
+                                 can_send_messages=False)
+
+        keyboard = [[InlineKeyboardButton(self._INLINE_BUTTON_TEXT, callback_data=f'{__name__}/{user.id}')]]
+        reply_markup = InlineKeyboardMarkup(keyboard, one_time_keyboard=True)
+
+        message.reply_text(
+            text=self._ON_JOIN_MESSAGE.format(username=username),
+            reply_markup=reply_markup)
+
+    def _process_captcha(self, bot, update):
+        query = update.callback_query
+        user = query.from_user
+
+        module, suspect_id = query.data.split('/')
+
+        if module != __name__:
+            return
+
+        suspect_id = int(suspect_id)
+
+        username = get_username_or_name(user)
+
+        if user.id != suspect_id:
+            bot.answer_callback_query(query.id, self._ON_ACCESS_RESTRICTED_MESSAGE.format(username=username),
+                                      show_alert=True)
+            return
+
+        bot.restrict_chat_member(self._chat_id,
+                                 suspect_id,
+                                 can_send_messages=True,
+                                 can_send_media_messages=True,
+                                 can_send_other_messages=True)
+
+        query.message.edit_text(text=self._ON_APPROVE_MESSAGE.format(username=username))

--- a/settings.py
+++ b/settings.py
@@ -15,3 +15,5 @@ URL = os.environ.get("URL")
 DATABASE_URL = os.environ["DATABASE_URL"]
 MAX_CONNECTIONS = os.environ.get("MAX_CONNECTIONS", 10)
 STALE_TIMEOUT = os.environ.get("STALE_TIMEOUT", 30)
+
+USER_JOIN_CAPTCHA_ENABLED = bool(os.environ.get("USER_JOIN_CAPTCHA_ENABLED", False))


### PR DESCRIPTION
Когда **пользователь входит** в супергруппу - у него **отбираются все права** на отправку сообщений, о чём сообщается в ответном сообщении. В этом же сообщении присутствует **кнопка**, на которую может нажать только этот пользователь, после чего **все права возвращаются**.

**Моменты, которые вызывают вопросы**:
 - добавление нескольких пользователей сразу - не протестировано; редкий случай
 - возможен абуз системы: если пользователю были ограничены права на канале - он может выйти и зайти, после чего все ограничения будут сняты

Что такое **"связные правки"**
В боте уже был обработчик для `CallbackQuery`, который находится в модуле `block_stickerpack`.

Так как в боте срабатывают **все** хэндлеры (даже одинаковые) для каждого из модулей - обработчик `CallbackQuery` из этого модуля вызывался вместе с таким же обработчиком в `block_stickerpack`.

Было принято решение как-то разграничить эти хэндлеры, поэтому для каждой кнопки `InlineKeyboardButton` в параметр `data` помимо нужных данных передается имя модуля, в котором эта кнопка была создана. В обработчике `CallbackQuery` эти данные разбиваются и идет проверка модуля: если модуль из `data` совпал с модулем, где идет проверка - мы попали в нужный хэндер.

```python
...
# создание кнопки с "data", в которой имя модуля и нужная информация
InlineKeyboardButton(self._INLINE_BUTTON_TEXT, callback_data=f'{__name__}/{user.id}'
...
# разбор "data"
module, suspect_id = query.data.split('/')

# удостоверимся, что мы в нужном модуле
if module != __name__:
    return
...
```

Несмотря на некоторые спорные моменты - работает приемлемо.