### PR TITLE
ReplyToPin: добавлен внятный ответ, если закрепленного сообщения нет

### DIFF
--- a/modules/reply_to_pin.py
+++ b/modules/reply_to_pin.py
@@ -4,6 +4,9 @@ from filters import PermittedChatFilter, supergroup_filter
 
 
 class ReplyToPin:
+    _PINNED_MESSAGE = '☝️️'
+    _NOT_PINNED_MESSAGE = 'Закрепленное сообщение отсутствует.'
+
     def __init__(self, chat_id, admin_id):
         self._chat_id = chat_id
         self._admin_id = admin_id
@@ -14,12 +17,12 @@ class ReplyToPin:
         add_handler(CommandHandler('pinned', callback=self.reply_to_pin,
                                    filters=self.permitted_chat_filter & supergroup_filter))
 
-    @staticmethod
-    def reply_to_pin(bot, update):
+    def reply_to_pin(self, bot, update):
         message = update.message
 
         chat = bot.get_chat(message.chat_id)
-        if chat.pinned_message is None:
-            return
 
-        chat.pinned_message.reply_text('☝️️', disable_notification=True)
+        if chat.pinned_message:
+            chat.pinned_message.reply_text(self._PINNED_MESSAGE, disable_notification=True)
+        else:
+            message.reply_text(self._NOT_PINNED_MESSAGE, disable_notification=True)


### PR DESCRIPTION
Ранее, когда вызывалась команда, а закрепленного сообщения не было - бот молчал. Это сбивало с толку, так как неясно, делает эта команда что-то или нет.