### PR TITLE
UserJoinCaptcha: исправлено восстановление прав на добавление превью ссылки

### DIFF
--- a/modules/user_join_captcha.py
+++ b/modules/user_join_captcha.py
@@ -67,6 +67,7 @@ class UserJoinCaptcha:
                                  suspect_id,
                                  can_send_messages=True,
                                  can_send_media_messages=True,
-                                 can_send_other_messages=True)
+                                 can_send_other_messages=True,
+                                 can_add_web_page_previews=True)
 
         query.message.edit_text(text=self._ON_APPROVE_MESSAGE.format(username=username))


### PR DESCRIPTION
Ранее, когда пользователь нажимал на кнопку, подтверждающую что он не бот, ему восстанавливались все права, кроме разрешения добавлять превью к ссылкам.