### PR TITLE
BlockStickerpack: рефакторинг

### DIFF
--- a/modules/block_stickerpack.py
+++ b/modules/block_stickerpack.py
@@ -4,14 +4,14 @@ from telegram.ext import CommandHandler, Filters, MessageHandler, CallbackQueryH
 
 from filters import PermittedChatFilter
 from model import BlockedStickerpack
-from utils import is_user_group_admin, get_username_or_name
+from utils import is_user_group_admin, get_username_or_name, grouper
 from utils import set_callback_data, process_callback_query, get_callback_data
 
 
 class BlockStickerpack:
     _STICKER_ADD_URL = 'https://t.me/addstickers/'
     _ADMIN_RESTRICTION_MESSAGE = 'Эта функция предназначена только для админов!'
-    _NO_STICKERPACKS_BLOCKED_MESSAGE = 'Заблокированных стикерпаков нет.'
+    _NO_STICKERPACKS_BLOCKED_MESSAGE = 'Заблокированных стикерпаков *нет*.'
 
     def __init__(self, chat_id, admin_id):
         self._chat_id = chat_id
@@ -25,7 +25,6 @@ class BlockStickerpack:
             self._watchdog))
         add_handler(CommandHandler('block_stickerpack', callback=self._block, filters=self.permitted_chat_filter))
         add_handler(CommandHandler('unblock_stickerpack', callback=self._unblock, filters=self.permitted_chat_filter))
-        add_handler(CommandHandler('list_stickerpacks', callback=self._list, filters=self.permitted_chat_filter))
         add_handler(CallbackQueryHandler(self._unblock_stickerpack_button))
 
     def _get_stickers_link(self, stickerpack_name):
@@ -34,20 +33,6 @@ class BlockStickerpack:
     @staticmethod
     def _get_blocked_stickerpacks():
         return BlockedStickerpack.select()
-
-    def _list(self, bot, update):
-        message = update.message
-
-        queryset = self._get_blocked_stickerpacks()
-
-        if queryset:
-            stickerpacks_list = (f'{index}. [{stickerpack.name}]({self._get_stickers_link(stickerpack.name)})'
-                                 for index, stickerpack in enumerate(queryset, start=1))
-            response_text = 'Заблокированные стикерпаки:\n' + '\n'.join(stickerpacks_list)
-        else:
-            response_text = self._NO_STICKERPACKS_BLOCKED_MESSAGE
-
-        message.reply_text(text=response_text, parse_mode=ParseMode.MARKDOWN, quote=False)
 
     def _block(self, bot, update):
         message = update.message
@@ -69,13 +54,13 @@ class BlockStickerpack:
         pack_link = self._get_stickers_link(pack_name)
 
         if not created:
-            response_text = f'Стикерпак [{pack_name}]({pack_link}) уже заблокирован.'
+            response_text = f'Стикерпак [{pack_name}]({pack_link}) *уже заблокирован*.'
         else:
             # mention_markdown позволяет кликнуть по пользователю и глянуть кто это, вместо простого имени / юзернейма
             sticker_from = message.reply_to_message.from_user.mention_markdown()
             who_block = message.from_user.mention_markdown()
 
-            response_text = f'Стикерпак [{pack_name}]({pack_link}) успешно заблокирован!\n' \
+            response_text = f'Стикерпак [{pack_name}]({pack_link}) успешно *заблокирован*!\n' \
                             f'Стикер отправил: {sticker_from} | Заблокировал: {who_block}'
 
         message.reply_text(text=response_text, parse_mode=ParseMode.MARKDOWN, quote=False)
@@ -89,22 +74,32 @@ class BlockStickerpack:
             return
 
         blocked_stickerpacks = self._get_blocked_stickerpacks()
-        if not blocked_stickerpacks:
+
+        packs_list = []
+        buttons = []
+
+        if blocked_stickerpacks:
+            for index, stickerpack in enumerate(blocked_stickerpacks, start=1):
+                packs_list.append(f'{index}. [{stickerpack.name}]({self._get_stickers_link(stickerpack.name)})')
+                buttons.append(
+                    InlineKeyboardButton(
+                        text=str(index),
+                        callback_data=set_callback_data(stickerpack.id))
+                )
+
+            response_text = '*Заблокированные стикерпаки:*\n{}\n\nКакой *разблокировать*?'.format("\n".join(packs_list))
+
+            keyboard = grouper(buttons, 5)  # в одном ряду будет 5 кнопок, так как текст на каждой из них короткий
+            reply_markup = InlineKeyboardMarkup(keyboard, one_time_keyboard=True)
+        else:
             response_text = self._NO_STICKERPACKS_BLOCKED_MESSAGE
             reply_markup = None
-        else:
-            response_text = 'Выберите стикерпак, который нужно разблокировать:'
-            keyboard = [[InlineKeyboardButton(f'{index}. {sp.name}', callback_data=set_callback_data(sp.name))]
-                        for index, sp in enumerate(blocked_stickerpacks, start=1)]
-            reply_markup = InlineKeyboardMarkup(keyboard, one_time_keyboard=True)
 
         message.reply_text(text=response_text, parse_mode=ParseMode.MARKDOWN, reply_markup=reply_markup, quote=False)
 
     @process_callback_query
     def _unblock_stickerpack_button(self, bot, update):
         query = update.callback_query
-
-        pack_name = get_callback_data(query.data)
 
         if query.from_user.id != self._admin_id and not is_user_group_admin(bot, query.from_user.id,
                                                                             query.message.chat_id, self._admin_id):
@@ -113,15 +108,19 @@ class BlockStickerpack:
 
         message = query.message
 
-        pack_link = self._get_stickers_link(pack_name)
+        pack_id = get_callback_data(query.data)
 
         try:
-            stickerpack = BlockedStickerpack.get(BlockedStickerpack.name == pack_name)
+            stickerpack = BlockedStickerpack.get(BlockedStickerpack.id == pack_id)
         except DoesNotExist:
-            response_text = f'Стикерпак "{pack_name}" не был найден в списке заблокированных.'
+            response_text = f'Выбранный стикерпак *не был найден* в списке заблокированных.'
         else:
+            pack_name = stickerpack.name
+            pack_link = self._get_stickers_link(pack_name)
+
             stickerpack.delete_instance()
-            response_text = f'Стикерпак [{pack_name}]({pack_link}) успешно разблокирован.'
+
+            response_text = f'Стикерпак [{pack_name}]({pack_link}) успешно *разблокирован*.'
 
         message.edit_text(text=response_text, parse_mode=ParseMode.MARKDOWN)
 

--- a/modules/block_stickerpack.py
+++ b/modules/block_stickerpack.py
@@ -71,8 +71,9 @@ class BlockStickerpack:
         if not created:
             response_text = f'Стикерпак [{pack_name}]({pack_link}) уже заблокирован.'
         else:
-            sticker_from = get_username_or_name(message.reply_to_message.from_user)
-            who_block = get_username_or_name(message.from_user)
+            # mention_markdown позволяет кликнуть по пользователю и глянуть кто это, вместо простого имени / юзернейма
+            sticker_from = message.reply_to_message.from_user.mention_markdown()
+            who_block = message.from_user.mention_markdown()
 
             response_text = f'Стикерпак [{pack_name}]({pack_link}) успешно заблокирован!\n' \
                             f'Стикер отправил: {sticker_from} | Заблокировал: {who_block}'

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,7 @@
 import functools
 import typing
 import inspect
+import itertools
 
 import supycache
 from telegram import Bot, User
@@ -58,3 +59,32 @@ def process_callback_query(func):
         return lambda: True  # помечает update с CallbackQuery обработанным, если ни один из хендлеров не подошел
 
     return inner
+
+
+def grouper(iterable, n):
+    """
+    Позволяет разбивать итерабельный обьект по группам размера n
+
+    В отличии от рецепта grouper(iterable, n, fillvalue=None) документации
+    itertools (https://docs.python.org/3/library/itertools.html#itertools-recipes)
+    не заполняет недостяющее количество элементов в группе при помощи fillvalue
+
+    Возвращает генератор
+
+    Пример:
+
+    >>> my_list = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+    >>> tuple(grouper(my_list, 3))
+    ((1, 2, 3), (4, 5, 6), (7, 8, 9))
+    >>> tuple(grouper(my_list, 6))
+    ((1, 2, 3, 4, 5, 6), (7, 8, 9))
+
+    """
+    it = iter(iterable)
+
+    while True:
+        res = tuple(itertools.islice(it, n))
+        if res:
+            yield res
+        else:
+            break


### PR DESCRIPTION
- команда для отображения заблокированных стикерпаков обьеденена с разблокировкой стикерпаков, так как одна без другой не имеют особой эффективности (всегда хочется увидеть превью стикерпака, который разблокируешь, а не определять по названию)

- на инлайн кнопках теперь указываются номера заблокированных стикерпаков из списка, для более эффективного использования места; нет смысла дублировать названия в сообщении и на кнопках;

- в одном ряде теперь отображается 5 кнопок; для достижения этой цели добавлена утилита `grouper` в модуль `utils.py`

- теперь в `callback_data` инлайн-кнопок передается не имя стикерпака, а его `id` в базе, так как у `callback_data` есть ограничение по размеру и большие названия стикерпаков могут препятствовать адекватной работе

- MARKDOWN теперь более активно задействуется, чтобы акцентировать внимание на важных частях сообщения

- в сообщении после блокировки стикерпака теперь отображаются кликабельные юзеры, вместо простого юзернейма / имени